### PR TITLE
private 라우트 수정, 필터링 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ function App() {
             token: {
               colorPrimary: '#2E8B57',
               fontFamily: 'Inter',
+              colorBgContainer: '#FBFBFB',
             },
           }}
         >

--- a/src/pages/items/components/SearchArea.tsx
+++ b/src/pages/items/components/SearchArea.tsx
@@ -1,27 +1,47 @@
 import { SearchOutlined } from '@ant-design/icons'
-import { Button, Input, Select } from 'antd'
+import { Button, Form, FormInstance, Input, Select } from 'antd'
 
-const SearchArea = () => {
+type Props = {
+  form: FormInstance<SearchAreaForm>
+}
+
+export type SearchAreaForm = {
+  name?: string
+  temp1?: string
+  order?: string
+}
+
+const SearchArea = ({ form }: Props) => {
   return (
-    <div className='flex justify-between mb-4'>
-      <div className='flex gap-x-3'>
-        <Input
-          size='middle'
-          placeholder='물품명으로 검색'
-          prefix={<SearchOutlined />}
-          className='w-48'
-        />
-        <Select placeholder='사용처 구분'>
-          <Select.Option value=''>전체</Select.Option>
-          <Select.Option value='1'>거실</Select.Option>
-          <Select.Option value='2'>욕실</Select.Option>
-        </Select>
-        <Select placeholder='정렬' className='w-48'>
-          <Select.Option value='1'>구매일 오래된 순</Select.Option>
-          <Select.Option value='2'>보관 장소</Select.Option>
-        </Select>
-      </div>
-      <Button type='primary'>물품 추가</Button>
+    <div className='flex flex-wrap justify-between mb-4'>
+      <Form form={form}>
+        <div className='flex flex-wrap gap-x-3'>
+          <Form.Item name='name'>
+            <Input
+              size='middle'
+              placeholder='물품명으로 검색'
+              prefix={<SearchOutlined />}
+              className='w-48'
+              allowClear
+            />
+          </Form.Item>
+          <Form.Item name='temp1'>
+            <Select placeholder='사용처 구분' allowClear>
+              <Select.Option value='거실'>거실</Select.Option>
+              <Select.Option value='욕실'>욕실</Select.Option>
+            </Select>
+          </Form.Item>
+          <Form.Item name='order'>
+            <Select placeholder='정렬' className='w-48' allowClear>
+              <Select.Option value='1'>구매일 오래된 순</Select.Option>
+              <Select.Option value='2'>보관 장소</Select.Option>
+            </Select>
+          </Form.Item>
+        </div>
+      </Form>
+      <Button type='primary' className='ml-auto'>
+        물품 추가
+      </Button>
     </div>
   )
 }

--- a/src/pages/items/components/tables/ConsumableTable.tsx
+++ b/src/pages/items/components/tables/ConsumableTable.tsx
@@ -4,23 +4,38 @@ import { DeleteFilled, EllipsisOutlined } from '@ant-design/icons'
 import { useQuery } from '@tanstack/react-query'
 import { Button, Tag, Tooltip } from 'antd'
 import { ColumnsType } from 'antd/es/table'
+import { SearchAreaForm } from '../SearchArea'
 
 // TODO
 const TYPE = 'CONSUMABLE'
 
-const ConsumableTable = () => {
+const ConsumableTable = ({ name, temp1 }: SearchAreaForm) => {
   const query = useQuery({
     queryKey: ['items'],
     queryFn: () => httpClient.items.getItems(),
     select(data) {
       // TODO
       // @ts-ignore
-      return data.data.map((item) => ({
-        ...item,
-        temp1: '거실',
-        temp2: '2022.10.01',
-        temp3: '2022.10.01',
-      }))
+      return data.data
+        .map((item) => ({
+          ...item,
+          temp1: '거실',
+          temp2: '2022.10.01',
+          temp3: '2022.10.01',
+        }))
+        .filter((item) => {
+          let result = true
+
+          if (name?.trim()) {
+            result = result && !!item.name?.includes(name.trim())
+          }
+
+          if (temp1) {
+            result = result && !!item.temp1?.includes(temp1)
+          }
+
+          return result
+        })
     },
   })
 
@@ -77,11 +92,15 @@ const ConsumableTable = () => {
       key: 'labels',
       align: 'center',
       render(_value, record, _index) {
-        return record.labels?.map((item) => (
-          <Tag key={item.labelNo} color='default'>
-            {item.name}
-          </Tag>
-        ))
+        return (
+          <div className='inline-flex flex-wrap gap-y-2'>
+            {record.labels?.map((item) => (
+              <Tag key={item.labelNo} color='default'>
+                {item.name}
+              </Tag>
+            ))}
+          </div>
+        )
       },
       width: 200,
     },

--- a/src/pages/items/components/tables/EquipmentTable.tsx
+++ b/src/pages/items/components/tables/EquipmentTable.tsx
@@ -2,18 +2,33 @@ import { httpClient, ItemRS } from '@/apis'
 import BasicTable from '@/components/tables/BasicTable'
 import { useQuery } from '@tanstack/react-query'
 import { ColumnsType } from 'antd/es/table'
+import { SearchAreaForm } from '../SearchArea'
 
 // TODO
 const TYPE = 'EQUIPMENT'
 
-const EquipmentTable = () => {
+const EquipmentTable = ({ name, temp1 }: SearchAreaForm) => {
   const query = useQuery({
     queryKey: ['items'],
     queryFn: () => httpClient.items.getItems(),
     select(data) {
       // TODO
       // @ts-ignore
-      return data.data.map((item) => ({ ...item, temp1: '거실' }))
+      return data.data
+        .map((item) => ({ ...item, temp1: '거실' }))
+        .filter((item) => {
+          let result = true
+
+          if (name?.trim()) {
+            result = result && !!item.name?.includes(name.trim())
+          }
+
+          if (temp1) {
+            result = result && !!item.temp1?.includes(temp1)
+          }
+
+          return result
+        })
     },
   })
 
@@ -27,7 +42,7 @@ const EquipmentTable = () => {
     },
     {
       title: '물품명',
-      dataIndex: '',
+      dataIndex: 'name',
       key: 'name',
       align: 'center',
       width: 200,

--- a/src/pages/items/components/tabs/ConsumableTab.tsx
+++ b/src/pages/items/components/tabs/ConsumableTab.tsx
@@ -1,11 +1,18 @@
-import SearchArea from '../SearchArea'
+import { Form } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import SearchArea, { SearchAreaForm } from '../SearchArea'
 import ConsumableTable from '../tables/ConsumableTable'
 
 const ConsumableTab = () => {
+  const [form] = useForm<SearchAreaForm>()
+
+  const name = Form.useWatch('name', form)
+  const temp1 = Form.useWatch('temp1', form)
+
   return (
     <>
-      <SearchArea />
-      <ConsumableTable />
+      <SearchArea form={form} />
+      <ConsumableTable name={name} temp1={temp1} />
     </>
   )
 }

--- a/src/pages/items/components/tabs/EquipmentTab.tsx
+++ b/src/pages/items/components/tabs/EquipmentTab.tsx
@@ -1,11 +1,18 @@
-import SearchArea from '../SearchArea'
+import { Form } from 'antd'
+import { useForm } from 'antd/lib/form/Form'
+import SearchArea, { SearchAreaForm } from '../SearchArea'
 import EquipmentTable from '../tables/EquipmentTable'
 
 const EquipmentTab = () => {
+  const [form] = useForm<SearchAreaForm>()
+
+  const name = Form.useWatch('name', form)
+  const temp1 = Form.useWatch('temp1', form)
+
   return (
     <>
-      <SearchArea />
-      <EquipmentTable />
+      <SearchArea form={form} />
+      <EquipmentTable name={name} temp1={temp1} />
     </>
   )
 }

--- a/src/pages/items/index.tsx
+++ b/src/pages/items/index.tsx
@@ -1,13 +1,18 @@
+import { userState } from '@/store'
 import { UserOutlined } from '@ant-design/icons'
 import { Avatar, Space, Tabs, TabsProps, Typography } from 'antd'
+import { useRecoilValue } from 'recoil'
 import ConsumableTab from './components/tabs/ConsumableTab'
 import EquipmentTab from './components/tabs/EquipmentTab'
 
 const Intro = () => {
+  const user = useRecoilValue(userState)!
   return (
     <Space wrap size={16} className='mb-2'>
       <Avatar size={64} icon={<UserOutlined />} />
-      <Typography.Title level={2}>안잉님 좋은 아침 입니다.</Typography.Title>
+      <Typography.Title level={2} className='m-0'>
+        {user.username}님 좋은 아침 입니다.
+      </Typography.Title>
     </Space>
   )
 }

--- a/src/routes/PrivateRoutes.tsx
+++ b/src/routes/PrivateRoutes.tsx
@@ -17,7 +17,7 @@ const Main = () => {
 const PrivateRoutes = () => {
   return (
     <Routes>
-      <Route path='/' element={<Main />}>
+      <Route element={<Main />}>
         <Route path={NavigationUtil.items} element={<ItemsPage />} />
         <Route path={NavigationUtil.locations} element={<LocationsPage />} />
         <Route path='*' element={<Navigate replace to={NavigationUtil.items} />} />


### PR DESCRIPTION
private 라우트 수정:  `/등록되지 않은 라우트` -> `/main` 화면으로 redirect하도록 변경
물품목록 필터링 구현:  `목록명`으로 필터링하도록 변경,     `사용처`, `정렬 종류`는 미정이므로 보류 